### PR TITLE
Add SOURCE env to checkout multiple repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ jobs:
       with:
         paths: somewhere/else
       env:
-        SOURCE: main
+        SOURCE: my-tools
 
     - name: Deploy main
       if: steps.changed-main.outputs.changed == 'true'

--- a/README.md
+++ b/README.md
@@ -110,13 +110,15 @@ jobs:
       id: changed-main
       with:
         paths: packages/front
-        source: main
+      env:
+        SOURCE: main
 
     - uses: marceloprado/has-changed-path@master
       id: changed-my-tools
       with:
         paths: somewhere/else
-        source: my-tools
+      env:
+        SOURCE: main
 
     - name: Deploy main
       if: steps.changed-main.outputs.changed == 'true'

--- a/README.md
+++ b/README.md
@@ -83,6 +83,50 @@ jobs:
       run: /deploy-front.sh
 ```
 
+### Detecting a one-path change with checkout multiple repos:
+
+```
+name: Conditional Deploy
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 100
+        path: main
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 100
+        repsitory: my-org/my-tools
+        path: my-tools
+
+    - uses: marceloprado/has-changed-path@master
+      id: changed-main
+      with:
+        paths: packages/front
+        source: main
+
+    - uses: marceloprado/has-changed-path@master
+      id: changed-my-tools
+      with:
+        paths: somewhere/else
+        source: my-tools
+
+    - name: Deploy main
+      if: steps.changed-main.outputs.changed == 'true'
+      run: /deploy-main.sh
+
+    - name: Deploy my tools
+      if: steps.changed-my-tools.outputs.changed == 'true'
+      run: /deploy-my-tools.sh
+```
+
 ## How it works?
 
 The action itself is pretty simple - take a look at `entrypoint.sh` ;) .

--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,6 @@ inputs:
   paths: # one or more paths
     description: "Paths to detect changes"
     required: true
-  source:
-    description: "Paths to source repository"
-    required: false
 outputs:
   changed:
     description: "Boolean indicating if the paths were changed in previous commit"

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   paths: # one or more paths
     description: "Paths to detect changes"
     required: true
+  source:
+    description: "Paths to source repository"
+    required: false
 outputs:
   changed:
     description: "Boolean indicating if the paths were changed in previous commit"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh -l
 set -euo pipefail
 
-source=${SOURCE:-.}
+SOURCE=${source:-.}
 
-cd ${GITHUB_WORKSPACE}/${source}
+cd ${GITHUB_WORKSPACE}/${SOURCE}
 
 # This script returns `true` if the paths passed as
 # arguments were changed in the last commit.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh -l
 set -euo pipefail
 
-SOURCE=${source:-.}
+source=${SOURCE:-.}
 
-cd ${GITHUB_WORKSPACE}/${SOURCE}
+cd ${GITHUB_WORKSPACE}/${source}
 
 # This script returns `true` if the paths passed as
 # arguments were changed in the last commit.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh -l
 set -euo pipefail
 
-source=${SOURCE:-.}
+SOURCE=${SOURCE:-.}
 
-cd ${GITHUB_WORKSPACE}/${source}
+cd ${GITHUB_WORKSPACE}/${SOURCE}
 
 # This script returns `true` if the paths passed as
 # arguments were changed in the last commit.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/sh -l
 set -euo pipefail
 
+source=${SOURCE:-.}
+
+cd ${GITHUB_WORKSPACE}/${source}
+
 # This script returns `true` if the paths passed as
 # arguments were changed in the last commit.
 


### PR DESCRIPTION
If checkout multiple repos with actions/checkout with path variable like https://github.com/actions/checkout#checkout-multiple-repos-side-by-side, there are separated several git directories. 
However, workflow main directory is not git directory(no .git directory), so entrypoint.sh must change directory to certain git directory.

inspired by:
https://github.com/anothrNick/github-tag-action